### PR TITLE
workaround - temporarily fixing deprecation warning

### DIFF
--- a/R/iterators.R
+++ b/R/iterators.R
@@ -36,7 +36,13 @@
 #' @name make-iterator
 #' @export
 make_iterator_one_shot <- function(dataset) {
-  dataset$make_one_shot_iterator()
+
+  if (tensorflow::tf_version() > "1.12") {
+    tf$compat$v1$data$make_one_shot_iterator(dataset)
+  } else {
+    dataset$make_one_shot_iterator()
+  }
+
 }
 
 


### PR DESCRIPTION
"last resort" temporary workaround according to 

```
DatasetV1.make_one_shot_iterator (from tensorflow.python.data.ops.dataset_ops) is deprecated
and will be removed in a future version.
Instructions for updating:
Use `for ... in dataset:` to iterate over a dataset. 
If using `tf.estimator`, return the `Dataset` object directly from your input function. 
As a last resort, you can use `tf.compat.v1.data.make_one_shot_iterator(dataset)`.
```