### PR TITLE
make tests run with TF 2.0 preview

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+# R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
+language: r
+
+dist: trusty
+sudo: false
+warnings_are_errors: false
+
+cache:
+  packages: true
+  directories:
+    - $HOME/.cache/pip
+
+matrix:
+  include:
+    - name: "tf-stable"
+      env: TENSORFLOW_VERSION="1.12"
+    - name: "2.0-preview"
+      env:
+        - TENSORFLOW_VERSION="https://files.pythonhosted.org/packages/20/6e/30238eaae78919134318856f4b7bffcfcb7d09be742565591208fa59e1cb/tf_nightly_2.0_preview-2.0.0.dev20190207-cp27-cp27mu-manylinux1_x86_64.whl"
+    - name: "nightly"
+      env:
+        - TENSORFLOW_VERSION="nightly"
+        - TENSORFLOW_PYTHON="/usr/bin/python3"
+  allow_failures:
+    - name: "2.0-preview"
+      env:
+        - TENSORFLOW_VERSION="https://files.pythonhosted.org/packages/20/6e/30238eaae78919134318856f4b7bffcfcb7d09be742565591208fa59e1cb/tf_nightly_2.0_preview-2.0.0.dev20190207-cp27-cp27mu-manylinux1_x86_64.whl"
+    - name: "nightly"
+      env:
+        - TENSORFLOW_VERSION="nightly"
+        - TENSORFLOW_PYTHON="/usr/bin/python3"
+
+before_script:
+  - sudo apt-get update
+  - sudo apt-get install python3
+  - pip install --upgrade --ignore-installed --user travis virtualenv
+  - R CMD INSTALL .
+- R -e 'tensorflow::install_tensorflow(version = Sys.getenv("TENSORFLOW_VERSION"))'

--- a/R/dataset_iterators.R
+++ b/R/dataset_iterators.R
@@ -67,7 +67,7 @@
 next_batch <- function(dataset) {
 
   # get the iterator
-  iter <- dataset$make_one_shot_iterator()
+  iter <- make_iterator_one_shot(dataset)
   next_batch <- iter$get_next()
 
   # re-arrange x and y if necessary

--- a/R/dataset_methods.R
+++ b/R/dataset_methods.R
@@ -52,7 +52,7 @@ dataset_shuffle <- function(dataset, buffer_size, seed = NULL) {
 dataset_shuffle_and_repeat <- function(dataset, buffer_size, count = NULL, seed = NULL) {
   validate_tf_version("1.8", "dataset_shuffle_and_repeat")
   as_tf_dataset(dataset$apply(
-    tf$contrib$data$shuffle_and_repeat(
+    tfd_shuffle_and_repeat(
       as_integer_tensor(buffer_size),
       as_integer_tensor(count),
       as_integer_tensor(seed)
@@ -199,7 +199,7 @@ dataset_map_and_batch <- function(dataset,
                                   num_parallel_calls = NULL) {
   validate_tf_version("1.8", "dataset_map_and_batch")
   as_tf_dataset(dataset$apply(
-    tf$contrib$data$map_and_batch(
+    tfd_map_and_batch(
       map_func,
       as.integer(batch_size),
       as_integer_tensor(num_parallel_batches),
@@ -263,7 +263,7 @@ dataset_prefetch <- function(dataset, buffer_size) {
 dataset_prefetch_to_device <- function(dataset, device, buffer_size = NULL) {
   validate_tf_version("1.8", "dataset_prefetch_to_device")
   as_tf_dataset(dataset$apply(
-    tf$contrib$data$prefetch_to_device(
+    tfd_prefetch_to_device(
       device = device,
       buffer_size = as_integer_tensor(buffer_size)
     )
@@ -588,7 +588,7 @@ dataset_prepare <- function(dataset, x, y = NULL, named = TRUE, named_features =
   }
 
 
-  # call appropriate mapping funciton
+  # call appropriate mapping function
   if (is.null(batch_size)) {
     dataset <- dataset %>%
       dataset_map(map_func = map_func,

--- a/R/iterators.R
+++ b/R/iterators.R
@@ -49,7 +49,12 @@ make_iterator_one_shot <- function(dataset) {
 #' @rdname make-iterator
 #' @export
 make_iterator_initializable <- function(dataset, shared_name = NULL) {
-  dataset$make_initializable_iterator(shared_name = shared_name)
+
+  if (tensorflow::tf_version() > "1.12") {
+    tf$compat$v1$data$make_initializable_iterator(dataset, shared_name = shared_name)
+  } else {
+    dataset$make_initializable_iterator(shared_name = shared_name)
+  }
 }
 
 
@@ -58,22 +63,40 @@ make_iterator_initializable <- function(dataset, shared_name = NULL) {
 #' @export
 make_iterator_from_structure <- function(output_types, output_shapes = NULL,
                                          shared_name = NULL) {
-  tf$data$Iterator$from_structure(
-    output_types = output_types,
-    output_shapes = output_shapes,
-    shared_name = shared_name
-  )
+
+  if (tensorflow::tf_version() > "1.12") {
+    tf$compat$v1$data$Iterator$from_structure(
+      output_types = output_types,
+      output_shapes = output_shapes,
+      shared_name = shared_name
+    )
+  } else {
+    tf$data$Iterator$from_structure(
+      output_types = output_types,
+      output_shapes = output_shapes,
+      shared_name = shared_name
+    )
+  }
 }
 
 #' @rdname make-iterator
 #' @export
 make_iterator_from_string_handle <- function(string_handle, output_types,
                                              output_shapes = NULL) {
-  tf$data$Iterator$from_string_handle(
-    string_handle = string_handle,
-    output_types = output_types,
-    output_shapes = output_shapes
-  )
+
+  if (tensorflow::tf_version() > "1.12") {
+    tf$compat$v1$data$Iterator$from_string_handle(
+      string_handle = string_handle,
+      output_types = output_types,
+      output_shapes = output_shapes
+    )
+  } else {
+    tf$data$Iterator$from_string_handle(
+      string_handle = string_handle,
+      output_types = output_types,
+      output_shapes = output_shapes
+    )
+  }
 }
 
 #' Get next element from iterator

--- a/R/sql_dataset.R
+++ b/R/sql_dataset.R
@@ -22,7 +22,7 @@ sql_dataset <- function(driver_name, data_source_name, query, record_spec) {
   validate_tf_version("1.7", "sql_dataset")
 
   # dataset
-  dataset <- tf$contrib$data$SqlDataset(
+  dataset <- tfd_SqlDataset(
     driver_name,
     data_source_name,
     query,

--- a/R/symbols.R
+++ b/R/symbols.R
@@ -1,0 +1,14 @@
+# Locations of symbols in TF 1.x vs TF 2.x
+
+# tf --> tf$random
+tfr_random_uniform <- if (tensorflow::tf_version() < "2.0") tf$random_uniform else tf$random$uniform
+
+# tf --> tf$io
+tfio_decode_csv<- if (tensorflow::tf_version() < "2.0") tf$decode_csv else tf$io$decode_csv
+
+# tf$contrib$data --> tf$data$experimental
+tfd_make_csv_dataset <- if (tensorflow::tf_version() < "2.0") tf$contrib$data$make_csv_dataset else tf$data$experimental$make_csv_dataset
+tfd_shuffle_and_repeat <- if (tensorflow::tf_version() < "2.0") tf$contrib$data$shuffle_and_repeat else tf$data$experimental$shuffle_and_repeat
+tfd_map_and_batch <- if (tensorflow::tf_version() < "2.0") tf$contrib$data$map_and_batch else tf$data$experimental$map_and_batch
+tfd_prefetch_to_device <- if (tensorflow::tf_version() < "2.0") tf$contrib$data$prefetch_to_device else tf$data$experimental$prefetch_to_device
+tfd_SqlDataset <- if (tensorflow::tf_version() < "2.0") tf$contrib$data$SqlDataset else tf$data$experimental$SqlDataset

--- a/R/symbols.R
+++ b/R/symbols.R
@@ -1,14 +1,14 @@
 # Locations of symbols in TF 1.x vs TF 2.x
 
 # tf --> tf$random
-tfr_random_uniform <- if (tensorflow::tf_version() < "2.0") tf$random_uniform else tf$random$uniform
+tfr_random_uniform <- function(...) if (tensorflow::tf_version() < "2.0") tf$random_uniform(...) else tf$random$uniform(...)
 
 # tf --> tf$io
-tfio_decode_csv<- if (tensorflow::tf_version() < "2.0") tf$decode_csv else tf$io$decode_csv
+tfio_decode_csv <- function(...) if (tensorflow::tf_version() < "2.0") tf$decode_csv(...) else tf$io$decode_csv(...)
 
 # tf$contrib$data --> tf$data$experimental
-tfd_make_csv_dataset <- if (tensorflow::tf_version() < "2.0") tf$contrib$data$make_csv_dataset else tf$data$experimental$make_csv_dataset
-tfd_shuffle_and_repeat <- if (tensorflow::tf_version() < "2.0") tf$contrib$data$shuffle_and_repeat else tf$data$experimental$shuffle_and_repeat
-tfd_map_and_batch <- if (tensorflow::tf_version() < "2.0") tf$contrib$data$map_and_batch else tf$data$experimental$map_and_batch
-tfd_prefetch_to_device <- if (tensorflow::tf_version() < "2.0") tf$contrib$data$prefetch_to_device else tf$data$experimental$prefetch_to_device
-tfd_SqlDataset <- if (tensorflow::tf_version() < "2.0") tf$contrib$data$SqlDataset else tf$data$experimental$SqlDataset
+tfd_make_csv_dataset <- function(...) if (tensorflow::tf_version() < "2.0") tf$contrib$data$make_csv_dataset(...) else tf$data$experimental$make_csv_dataset(...)
+tfd_shuffle_and_repeat <- function(...) if (tensorflow::tf_version() < "2.0") tf$contrib$data$shuffle_and_repeat(...) else tf$data$experimental$shuffle_and_repeat(...)
+tfd_map_and_batch <- function(...) if (tensorflow::tf_version() < "2.0") tf$contrib$data$map_and_batch(...) else tf$data$experimental$map_and_batch(...)
+tfd_prefetch_to_device <- function(...) if (tensorflow::tf_version() < "2.0") tf$contrib$data$prefetch_to_device(...) else tf$data$experimental$prefetch_to_device(...)
+tfd_SqlDataset <- function(...) if (tensorflow::tf_version() < "2.0") tf$contrib$data$SqlDataset(...) else tf$data$experimental$SqlDataset(...)

--- a/R/text_line_dataset.R
+++ b/R/text_line_dataset.R
@@ -69,7 +69,7 @@ dataset_decode_delim <- function(dataset, record_spec, parallel_records = NULL) 
     dataset_skip(record_spec$skip) %>%
     dataset_map(
       map_func = function(line) {
-        decoded <- tf$decode_csv(
+        decoded <- tfio_decode_csv(
           records = line,
           record_defaults = record_spec$defaults,
           field_delim = record_spec$delim
@@ -201,7 +201,7 @@ make_csv_dataset <- function(file_pattern, batch_size,
     args[['num_parallel_parser_calls']] <- as.integer(num_parallel_parser_calls)
   }
 
-  do.call(tf$contrib$data$make_csv_dataset, args)
+  do.call(tfd_make_csv_dataset, args)
 }
 
 

--- a/tests/testthat/test-dataset-iterators.R
+++ b/tests/testthat/test-dataset-iterators.R
@@ -4,36 +4,51 @@ source("utils.R")
 
 test_succeeds("with_dataset catches end of iteration", {
 
-  sess <- tf$Session()
-  on.exit(sess$close(), add = TRUE)
   dataset <- tensor_slices_dataset(1:50) %>%
     dataset_batch(10)
-  batch <- next_batch(dataset)
 
-  with_dataset({
-    while(TRUE) {
-      value <- sess$run(batch)
-      print(value)
-    }
-  })
-
+  if (tf$executing_eagerly()) {
+    iter <- make_iterator_one_shot(dataset)
+    with_dataset({
+      while (TRUE) {
+        batch <- iterator_get_next(iter)
+        print(batch)
+      }
+    })
+  } else {
+    batch <- next_batch(dataset)
+    with_session(function (sess) {
+      with_dataset({
+        while (TRUE) {
+          value <- sess$run(batch)
+          print(value)
+        }
+      })
+    })
+  }
 })
 
 test_succeeds("until_out_of_range catches end of iteration", {
 
-  sess <- tf$Session()
-  on.exit(sess$close(), add = TRUE)
   dataset <- tensor_slices_dataset(1:50) %>%
     dataset_batch(10)
-  batch <- next_batch(dataset)
 
-  until_out_of_range({
-    value <- sess$run(batch)
-    print(value)
-  })
-
+  if (tf$executing_eagerly()) {
+    iter <- make_iterator_one_shot(dataset)
+    until_out_of_range({
+        batch <- iterator_get_next(iter)
+        print(batch)
+    })
+  } else {
+    batch <- next_batch(dataset)
+    with_session(function (sess) {
+      until_out_of_range({
+          value <- sess$run(batch)
+          print(value)
+      })
+    })
+  }
 })
-
 
 test_succeeds("until_out_of_range catches break", {
   until_out_of_range({

--- a/tests/testthat/test-dataset-methods.R
+++ b/tests/testthat/test-dataset-methods.R
@@ -89,10 +89,17 @@ test_succeeds("dataset_filter narrows the dataset", {
     }) %>%
     dataset_batch(1000)
 
-  sess <- tf$Session()
-  on.exit(sess$close(), add = TRUE)
   batch <- next_batch(dataset)
-  expect_length(sess$run(batch)$mpg, 3)
+
+  res <- if (tf$executing_eagerly()) {
+    batch$mpg
+  } else {
+    with_session(function (sess) {
+      sess$run(batch)$mpg
+    })
+  }
+
+  expect_length(res, 3)
 })
 
 test_succeeds("dataset_interleave yields a dataset" , {
@@ -109,10 +116,17 @@ test_succeeds("dataset_shard yields a dataset" , {
     dataset_shard(num_shards = 4, index = 1) %>%
     dataset_batch(8)
 
-  sess <- tf$Session()
-  on.exit(sess$close(), add = TRUE)
   batch <- next_batch(dataset)
-  expect_length(sess$run(batch)$mpg, 8)
+
+  res <- if (tf$executing_eagerly()) {
+    batch$mpg
+  } else {
+    with_session(function (sess) {
+      sess$run(batch)$mpg
+    })
+  }
+
+  expect_length(res, 8)
 
 })
 

--- a/tests/testthat/test-fixed-length-datasets.R
+++ b/tests/testthat/test-fixed-length-datasets.R
@@ -10,10 +10,14 @@ test_succeeds("fixed_length_record_dataset creates a dataset", {
   dataset <- fixed_length_record_dataset(
     "data/mtcars-test.csv", record_bytes = file_bytes)
 
-  with_session(function(sess) {
+  if (tf$executing_eagerly()) {
     batch <- next_batch(dataset)
-    file_contents <- sess$run(batch)
-  })
+  } else {
+    with_session(function(sess) {
+      batch <- next_batch(dataset)
+      file_contents <- sess$run(batch)
+    })
+  }
 
 })
 

--- a/tests/testthat/test-input-fn.R
+++ b/tests/testthat/test-input-fn.R
@@ -36,6 +36,7 @@ use_input_fn <- function(features, response) {
 }
 
 test_succeeds("input_fn feeds data to train and evaluate", {
+  skip_if_v2("tfestimators has not yet been adapted to work with TF 2.0")
   use_input_fn(features = c("disp", "cyl"), response = "mpg")
 })
 
@@ -89,6 +90,8 @@ test_succeeds("input_fn accepts formula syntax", {
 test_succeeds("input_fn works with custom estimators", {
 
   skip_if_no_tensorflow()
+
+  skip_if_v2("tfestimators has not yet been adapted to work with TF 2.0")
 
   require(tfestimators)
 

--- a/tests/testthat/test-range-dataset.R
+++ b/tests/testthat/test-range-dataset.R
@@ -3,12 +3,20 @@ context("range dataset")
 source("utils.R")
 
 test_succeeds("range_dataset creates a dataset", {
-  sess <- tf$Session()
-  on.exit(sess$close(), add = TRUE)
-  expect_equal(
-    sess$run(next_batch(range_dataset(from = 1, to = 11) %>% dataset_batch(10))),
-    array(1L:10L)
-  )
+
+  dataset <- range_dataset(from = 1, to = 11) %>% dataset_batch(10)
+  batch <- next_batch(dataset)
+
+  res <- if (tf$executing_eagerly()) {
+    as.array(batch)
+  } else {
+    with_session(function (sess) {
+      sess$run(batch)
+    })
+  }
+
+  expect_equal(res, array(1L:10L))
+
 })
 
 

--- a/tests/testthat/test-read-files.R
+++ b/tests/testthat/test-read-files.R
@@ -11,11 +11,14 @@ test_succeeds("files can be read in parallel", {
                         num_shards = 2, shard_index = 0) %>%
     dataset_batch(1000)
 
-  with_session(function(sess) {
+  if (tf$executing_eagerly()) {
     batch <- next_batch(dataset)
-    data <- sess$run(batch)
-  })
-
+  } else {
+    with_session(function(sess) {
+      batch <- next_batch(dataset)
+      data <- sess$run(batch)
+    })
+  }
 
 })
 

--- a/tests/testthat/test-tensor-datasets.R
+++ b/tests/testthat/test-tensor-datasets.R
@@ -11,6 +11,9 @@ test_succeeds("tensor_slices_dataset create a dataset", {
 })
 
 test_succeeds("sparse_tensor_slices_dataset creates a dataset", {
+
+  skip_if_v2("from_sparse_tensor_slices is not available in TF 2.0")
+
   sparse_tensor_slices_dataset(tf$SparseTensor(
     indices = list(c(0L, 0L), c(1L, 2L)),
     values = c(1L, 2L),

--- a/tests/testthat/utils.R
+++ b/tests/testthat/utils.R
@@ -12,6 +12,16 @@ skip_if_no_tensorflow <- function(required_version = NULL) {
   }
 }
 
+skip_if_eager <- function(message) {
+  if (tf$executing_eagerly())
+    skip(message)
+}
+
+skip_if_v2 <- function(message) {
+  if (tensorflow::tf_version() >= "2.0")
+    skip(message)
+}
+
 test_succeeds <- function(desc, expr, required_version = NULL) {
   test_that(desc, {
     skip_if_no_tensorflow(required_version)
@@ -30,6 +40,9 @@ mtcars_dataset <- function() {
     dataset_batch(10)
 }
 
-
+mtcars_dataset_nobatch <- function() {
+  csv_dataset("data/mtcars.csv") %>%
+    dataset_shuffle(50)
+}
 
 


### PR DESCRIPTION
With these fixes the tests run successfully against TF 2.0 preview.

Against __TF 1.12__, 2 estimator-related tests fail (these have been failing before).  (For 2.0, I've disabled them as anyway they'd fail due to `tf.logging` usage in `tfestimators`.)

Anyway we should investigate further why they fail (changes in `tidyselect` behavior?) - here they are, for later reference:

```
???: failure: input_fn feeds data to train and evaluate
`force(expr)` threw an error.
Message: object 'features' not found
Class:   simpleError/error/condition

???: failure: input_fn works with custom estimators
`force(expr)` threw an error.
Message: RuntimeError: Evaluation error: object 'feature_names' not found.

```

I'll also add a travis config file analogously to `tensorflow`.

Regarding the changes, LMK what you think of the `symbols.R` approach - first I had this branching spread over the individual locations of use, but then I thought I'd aggregate them all in one file, also because we don't know how much "in flux" this all still is on the TF side.