### PR TITLE
Store dtype string

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['windows-latest', 'macOS-latest', 'ubuntu-16.04']
-        tf: ['1.14.0', '1.15.2', '2.0.1', '2.1.0', '2.2.0', 'nightly']
+        tf: ['2.0.1', '2.1.0', '2.2.0', '2.3', '2.4', 'nightly']
         include:
           - os: ubuntu-16.04
             cran: https://demo.rstudiopm.com/all/__linux__/xenial/latest

--- a/R/dataset_methods.R
+++ b/R/dataset_methods.R
@@ -182,7 +182,7 @@ dataset_take <- function(dataset, count) {
 dataset_map <- function(dataset, map_func, num_parallel_calls = NULL) {
   as_tf_dataset(dataset$map(
     map_func = as_py_function(map_func),
-    num_parallel_calls = as_integer_tensor(num_parallel_calls, tf$int32)
+    num_parallel_calls = as_integer_tensor(num_parallel_calls, tf$int64)
   ))
 }
 

--- a/R/feature_spec.R
+++ b/R/feature_spec.R
@@ -16,6 +16,19 @@ dtype_chr <- function(x) {
   x$name
 }
 
+chr_dtype <- function(x) {
+  if (x == "float32")
+    tensorflow::tf$float32
+  else if (x == "string")
+    tensorflow::tf$string
+  else if (x == "float64")
+    tensorflow::tf$float64
+  else if (x == "float16")
+    tensorflow::tf$float16
+  else if (x == "bool")
+    tensorflow::tf$bool
+}
+
 # Selectors ---------------------------------------------------------------
 
 #' Selectors
@@ -514,7 +527,7 @@ StepNumericColumn <- R6::R6Class(
       self$key <- key
       self$shape <- shape
       self$default_value <- default_value
-      self$dtype <- dtype
+      self$dtype <- dtype_chr(dtype)
       self$normalizer_fn <- normalizer_fn
       self$name <- name
       self$column_type = dtype_chr(dtype)
@@ -534,7 +547,7 @@ StepNumericColumn <- R6::R6Class(
       tf$feature_column$numeric_column(
         key = self$key, shape = self$shape,
         default_value = self$default_value,
-        dtype = self$dtype,
+        dtype = chr_dtype(self$dtype),
         normalizer_fn = self$normalizer_fn
       )
     }
@@ -561,7 +574,7 @@ StepCategoricalColumnWithVocabularyList <- R6::R6Class(
 
       self$key <- key
       self$vocabulary_list <- vocabulary_list
-      self$dtype = dtype
+      self$dtype = dtype_chr(dtype)
       self$default_value <- default_value
       self$num_oov_buckets <- num_oov_buckets
       self$name <- name
@@ -614,7 +627,7 @@ StepCategoricalColumnWithVocabularyList <- R6::R6Class(
       tf$feature_column$categorical_column_with_vocabulary_list(
         key = self$key,
         vocabulary_list = self$vocabulary_list,
-        dtype = self$dtype,
+        dtype = dtype_chr(self$dtype),
         default_value = self$default_value,
         num_oov_buckets = self$num_oov_buckets
       )
@@ -637,7 +650,7 @@ StepCategoricalColumnWithHashBucket <- R6::R6Class(
     initialize = function(key, hash_bucket_size, dtype = tf$string, name) {
       self$key <- key
       self$hash_bucket_size <- hash_bucket_size
-      self$dtype <- dtype
+      self$dtype <- dtype_chr(dtype)
       self$name <- name
       if (!is.null(dtype)) {
         self$column_type = dtype_chr(dtype)
@@ -647,7 +660,7 @@ StepCategoricalColumnWithHashBucket <- R6::R6Class(
       tf$feature_column$categorical_column_with_hash_bucket(
         key = self$key,
         hash_bucket_size = self$hash_bucket_size,
-        dtype = self$dtype
+        dtype = chr_dtype(self$dtype)
       )
     }
   )
@@ -696,7 +709,7 @@ StepCategoricalColumnWithVocabularyFile <- R6::R6Class(
       self$key <- key
       self$vocabulary_file <- normalizePath(vocabulary_file)
       self$vocabulary_size <- vocabulary_size
-      self$dtype <- dtype
+      self$dtype <- dtype_chr(dtype)
       self$default_value <- default_value
       self$num_oov_buckets <- num_oov_buckets
       self$name <- name
@@ -709,7 +722,7 @@ StepCategoricalColumnWithVocabularyFile <- R6::R6Class(
         key = self$key,
         vocabulary_file = self$vocabulary_file,
         vocabulary_size = self$vocabulary_size,
-        dtype = self$dtype,
+        dtype = chr_dtype(self$dtype),
         default_value = self$default_value,
         num_oov_buckets = self$num_oov_buckets
       )


### PR DESCRIPTION
Fix #53 

This allows saving and reloading models that include a normalizer_fn:

```
data <- data.frame(
    y = runif(5),
    x = runif(5),
    b = runif(5)
  )

  spec <- feature_spec(data, y ~ .) %>%
    step_numeric_column(x, normalizer_fn = scaler_standard()) %>%
    fit()

  input <- layer_input_from_dataset(data[-1])
  output <- input %>%
    layer_dense_features(dense_features(spec)) %>%
    layer_dense(units = 1, activation = "sigmoid")
  model <- keras_model(input, output)

  model %>% compile(
    loss = "binary_crossentropy",
    optimizer = "adam",
    metrics = "binary_accuracy"
  )

  tmp <- tempfile("model")
  rds <- tempfile("rds")

  save_model_weights_tf(model, tmp)
  saveRDS(spec, rds)

  reloaded_spec <- readRDS(rds)
  input <- layer_input_from_dataset(data[-1])
  output <- input %>%
    layer_dense_features(dense_features(reloaded_spec)) %>%
    layer_dense(units = 1, activation = "sigmoid")
  new_model <- keras_model(input, output)
  load_model_weights_tf(new_model, tmp)

  expect_equal(
    predict(model, data[-1]),
    predict(new_model, data[-1])
  )
```

Unfortunately it's not possible to save the entire model as there's no way for python to know how to serialize the normalization function.

The only way is to save weights and the spec in a separate files and reloading them at prediction time.